### PR TITLE
fix draw_panel function definition

### DIFF
--- a/R/geom_polypath.R
+++ b/R/geom_polypath.R
@@ -82,7 +82,7 @@ GeomPolypath <- ggproto(
   "GeomPolypath",
   GeomPolygon,
   extra_params = c("na.rm", "rule"),
-  draw_panel = function(data, scales, coordinates, rule) {
+  draw_panel = function(self, data, scales, coordinates, rule) {
     n <- nrow(data)
     if (n == 1)
       return(zeroGrob())


### PR DESCRIPTION
It appears that the ggproto function definitions for new versions of ggplot needs to include "self" as the first argument (https://github.com/tidyverse/ggplot2/blob/master/R/geom-.r#L92), or ggplot will throw an error ("Error: GeomPolypath was built with an incompatible version of ggproto. Please reinstall the package that provides this extension."). I couldn't get this message to go away until I added "self" to the function definition, but perhaps this is specific to my system. Thoughts?